### PR TITLE
fix java.lang.SecurityException on Android 14+

### DIFF
--- a/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlModule.java
@@ -40,6 +40,7 @@ import java.net.URLConnection;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import static android.content.Context.RECEIVER_NOT_EXPORTED;
 
 public class MusicControlModule extends ReactContextBaseJavaModule implements ComponentCallbacks2 {
     private static final String TAG = MusicControlModule.class.getSimpleName();
@@ -204,8 +205,12 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
         filter.addAction(MusicControlNotification.MEDIA_BUTTON);
         filter.addAction(Intent.ACTION_MEDIA_BUTTON);
         filter.addAction(AudioManager.ACTION_AUDIO_BECOMING_NOISY);
-        receiver = new MusicControlReceiver(this, context);
-        context.registerReceiver(receiver, filter);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+					context.registerReceiver(receiver, filter, RECEIVER_NOT_EXPORTED);
+				} else {
+					context.registerReceiver(receiver, filter);
+				}
 
         Intent myIntent = new Intent(context, MusicControlNotification.NotificationService.class);
 
@@ -279,8 +284,12 @@ public class MusicControlModule extends ReactContextBaseJavaModule implements Co
 
         ReactApplicationContext context = getReactApplicationContext();
 
-        context.unregisterReceiver(receiver);
-        context.unregisterComponentCallbacks(this);
+        try {
+					context.unregisterReceiver(receiver);
+					context.unregisterComponentCallbacks(this);
+        } catch (Exception e) {
+					// java.lang.IllegalArgumentException: Receiver not registered: null
+        }
 
         if (artworkThread != null && artworkThread.isAlive())
             artworkThread.interrupt();


### PR DESCRIPTION
I have an exception in my App on android 14 and 15.

```
Exception java.lang.SecurityException:
  at android.os.Parcel.createExceptionOrNull (Parcel.java:3099)
  at android.os.Parcel.createException (Parcel.java:3083)
  at android.os.Parcel.readException (Parcel.java:3066)
  at android.os.Parcel.readException (Parcel.java:3008)
  at android.app.IActivityManager$Stub$Proxy.registerReceiverWithFeature (IActivityManager.java:5737)
  at android.app.ContextImpl.registerReceiverInternal (ContextImpl.java:1988)
  at android.app.ContextImpl.registerReceiver (ContextImpl.java:1923)
  at android.app.ContextImpl.registerReceiver (ContextImpl.java:1911)
  at android.content.ContextWrapper.registerReceiver (ContextWrapper.java:755)
  at android.content.ContextWrapper.registerReceiver (ContextWrapper.java:755)
  at com.tanguyantoine.react.MusicControlModule.init (MusicControlModule.java:208)
  at com.tanguyantoine.react.MusicControlModule.updatePlayback (MusicControlModule.java:435)
  at java.lang.reflect.Method.invoke
  at com.facebook.react.bridge.JavaMethodWrapper.invoke (JavaMethodWrapper.java:372)
  at com.facebook.react.bridge.JavaModuleWrapper.invoke (JavaModuleWrapper.java:146)
  at com.facebook.jni.NativeRunnable.run
  at android.os.Handler.handleCallback (Handler.java:996)
  at android.os.Handler.dispatchMessage (Handler.java:110)
  at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage (MessageQueueThreadHandler.kt:20)
  at android.os.Looper.loopOnce (Looper.java:210)
  at android.os.Looper.loop (Looper.java:302)
  at com.facebook.react.bridge.queue.MessageQueueThreadImpl$Companion.startNewBackgroundThread$lambda$1 (MessageQueueThreadImpl.kt:175)
  at com.facebook.react.bridge.queue.MessageQueueThreadImpl$Companion.$r8$lambda$ldnZnqelhYFctGaUKkOKYj5rxo4 (Unknown Source)
  at com.facebook.react.bridge.queue.MessageQueueThreadImpl$Companion$$ExternalSyntheticLambda0.run (D8$$SyntheticClass)
  at java.lang.Thread.run (Thread.java:1012)
Caused by android.os.RemoteException: Remote stack trace:
  at com.android.server.am.ActivityManagerService.registerReceiverWithFeature (ActivityManagerService.java:15256)
  at android.app.IActivityManager$Stub.onTransact (IActivityManager.java:2595)
  at com.android.server.am.ActivityManagerService.onTransact (ActivityManagerService.java:2994)
  at com.android.server.am.HwActivityManagerService.onTransact (HwActivityManagerService.java:292)
  at android.os.Binder.execTransactInternal (Binder.java:1366)
```

I found out that the reason is in the `context.registerReceiver` call: https://stackoverflow.com/a/77276774/4177749
So I made this change and got another crash on  `context.unregisterReceiver`. I applied the `try ... catch` solution which is probably not the best but it works: https://stackoverflow.com/a/36530677/4177749

Hope this helps someone.